### PR TITLE
Add leaderboard-informed copy trading workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,9 @@ KALSHI_ENV=demo
 KALSHI_DRY_RUN=true
 KALSHI_DEFAULT_ORDER_COUNT=1
 KALSHI_DEFAULT_MAX_PRICE_CENTS=1
+KALSHI_COMBO_MIN_SIGNALS=2
+KALSHI_COMBO_MIN_EDGE_CENTS=3
+KALSHI_COMBO_MIN_CONFIDENCE_CENTS=55
 
 # Optional: use Apify's third-party Kalshi leaderboard scraper for `kalshi-bot leaderboard`.
 # You can avoid this dependency by saving leaderboard JSON locally and passing --file/--leaderboard-file.

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,29 @@
+# Copy this file to .env and keep .env out of git.
+# The API key ID is the UUID displayed in Kalshi Account & security -> API Keys.
+KALSHI_API_KEY_ID=your-api-key-id
+
+# Download your Kalshi RSA private key and point to it here. Do not commit it.
+KALSHI_PRIVATE_KEY_PATH=/absolute/path/to/kalshi.key
+
+# demo or production; credentials do not work across environments.
+KALSHI_ENV=demo
+
+# Safety default: keep true unless you intentionally want live orders.
+KALSHI_DRY_RUN=true
+KALSHI_DEFAULT_ORDER_COUNT=1
+KALSHI_DEFAULT_MAX_PRICE_CENTS=1
+
+# Optional: use Apify's third-party Kalshi leaderboard scraper for `kalshi-bot leaderboard`.
+# You can avoid this dependency by saving leaderboard JSON locally and passing --file/--leaderboard-file.
+APIFY_API_TOKEN=
+KALSHI_LEADERBOARD_METRIC=projected_pnl
+KALSHI_LEADERBOARD_TIMEFRAME=monthly
+KALSHI_LEADERBOARD_CATEGORY=
+
+# Copy-trading guardrails. Keep strict while paper-testing.
+KALSHI_COPY_MIN_PROJECTED_PNL_CENTS=10000
+KALSHI_COPY_MIN_ROI_PERCENT=
+KALSHI_COPY_MIN_MARKETS_TRADED=5
+KALSHI_COPY_MAX_RANK=25
+KALSHI_COPY_MIN_MARKET_VOLUME=0
+KALSHI_COPY_ALLOWED_CATEGORIES=

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Python
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.venv/
+venv/
+
+# Local credentials and runtime output
+.env
+*.key
+*.pem
+logs/

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A safety-first Python scaffold for a Kalshi event-contract trading bot. It uses 
 - Authenticated balance and order endpoints with `KALSHI-ACCESS-*` headers.
 - RSA private-key request signing.
 - A tiny starter strategy that selects open markets with displayed asks at or below a configurable maximum.
+- A combo-prediction strategy that requires multiple independent prediction inputs for the same market before considering an order.
 - Dry-run safeguards that require both `KALSHI_DRY_RUN=false` and `--live` before submitting an order.
 - Optional Kalshi social leaderboard ingestion from a local JSON export or the third-party Apify scraper, with copy-trading filters for profit, ROI, rank, history, market volume, category, and price.
 
@@ -52,6 +53,25 @@ Run the sample strategy in dry-run mode:
 ```bash
 kalshi-bot run --limit 20 --max-price-cents 1 --count 1
 ```
+
+Run the combo-prediction strategy with a local prediction file:
+
+```bash
+kalshi-bot run --strategy combo-prediction --predictions-file predictions.json --max-price-cents 40 --min-combo-signals 2 --min-edge-cents 5
+```
+
+Example `predictions.json`:
+
+```json
+{
+  "predictions": [
+    {"ticker": "EXAMPLE-26", "probability": 0.66, "source": "model-a", "weight": 1.0},
+    {"ticker": "EXAMPLE-26", "probability": "62%", "source": "model-b", "weight": 0.8}
+  ]
+}
+```
+
+The combo strategy converts each row into a YES-probability estimate, computes a weighted combo probability, then only picks YES or NO when enough sources agree and the predicted probability clears the configured confidence and edge thresholds.
 
 Submit a live order only after you intentionally disable the environment safety and pass `--live`:
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,114 @@
+# Kalshi Trading Bot
+
+A safety-first Python scaffold for a Kalshi event-contract trading bot. It uses Kalshi Trade API v2, signs authenticated requests with RSA-PSS, and defaults to dry-run mode so you can inspect decisions before any order is submitted.
+
+> This project is engineering scaffolding, not financial advice. Replace the sample strategy before risking capital.
+
+## What is included
+
+- Public market browsing (`GET /markets`).
+- Authenticated balance and order endpoints with `KALSHI-ACCESS-*` headers.
+- RSA private-key request signing.
+- A tiny starter strategy that selects open markets with displayed asks at or below a configurable maximum.
+- Dry-run safeguards that require both `KALSHI_DRY_RUN=false` and `--live` before submitting an order.
+- Optional Kalshi social leaderboard ingestion from a local JSON export or the third-party Apify scraper, with copy-trading filters for profit, ROI, rank, history, market volume, category, and price.
+
+## Setup
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e '.[dev]'
+cp .env.example .env
+```
+
+Edit `.env` with your Kalshi credentials:
+
+```dotenv
+KALSHI_API_KEY_ID=your-api-key-id
+KALSHI_PRIVATE_KEY_PATH=/absolute/path/to/kalshi.key
+KALSHI_ENV=demo
+KALSHI_DRY_RUN=true
+```
+
+Kalshi credentials have two parts: the API key ID UUID and a downloaded RSA private-key file. The UUID alone is not enough for authenticated requests.
+
+## Commands
+
+List open markets without credentials:
+
+```bash
+kalshi-bot markets --limit 5
+```
+
+Fetch your balance with signed authentication:
+
+```bash
+kalshi-bot balance
+```
+
+Run the sample strategy in dry-run mode:
+
+```bash
+kalshi-bot run --limit 20 --max-price-cents 1 --count 1
+```
+
+Submit a live order only after you intentionally disable the environment safety and pass `--live`:
+
+```bash
+KALSHI_DRY_RUN=false kalshi-bot run --limit 20 --max-price-cents 1 --count 1 --live
+```
+
+## Leaderboard-informed copy trading
+
+Kalshi's leaderboard is useful social/performance context, but a leaderboard row by itself is **not** a current trade to copy. The bot therefore separates two steps:
+
+1. Load and filter leaderboard rows to identify traders worth watching.
+2. Evaluate explicit public signals (for example, a saved post/export that includes `leader_handle`, `ticker`, `side`, and `price_cents`) against strict risk gates before any order can be placed.
+
+Fetch/filter leaderboard rows from a local JSON export:
+
+```bash
+kalshi-bot leaderboard --file leaderboard.json --limit 10
+```
+
+Or opt into the third-party Apify scraper by setting `APIFY_API_TOKEN`, then run:
+
+```bash
+kalshi-bot leaderboard --metric projected_pnl --timeframe monthly --limit 10
+```
+
+Example `signals.json`:
+
+```json
+{
+  "signals": [
+    {
+      "leader_handle": "example-trader",
+      "ticker": "EXAMPLE-26",
+      "side": "bid",
+      "price_cents": 4,
+      "count": 1,
+      "reason": "public social post/export"
+    }
+  ]
+}
+```
+
+Evaluate signals in dry-run mode:
+
+```bash
+kalshi-bot copy --signals-file signals.json --leaderboard-file leaderboard.json --max-price-cents 5
+```
+
+Submit approved copy orders only after paper-testing and after you intentionally disable both safety gates:
+
+```bash
+KALSHI_DRY_RUN=false kalshi-bot copy --signals-file signals.json --leaderboard-file leaderboard.json --max-price-cents 5 --live
+```
+
+The copy workflow refuses to infer private trades from leaderboard rank alone and only submits explicit, reviewed signals that pass the configured filters.
+
+## Credential safety
+
+The local `.env` file, `.key` files, and `.pem` files are ignored by git. Do not commit your Kalshi private key. If you rotate credentials, update your local `.env` and private-key path only.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "kalshi-trading-bot"
+version = "0.1.0"
+description = "A safety-first Kalshi trading bot scaffold with signed API requests."
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+  "cryptography>=42.0.0",
+  "requests>=2.31.0",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0.0"]
+
+[project.scripts]
+kalshi-bot = "kalshi_bot.cli:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+testpaths = ["tests"]

--- a/src/kalshi_bot/__init__.py
+++ b/src/kalshi_bot/__init__.py
@@ -1,0 +1,4 @@
+"""Safety-first Kalshi trading bot package."""
+
+__all__ = ["__version__"]
+__version__ = "0.1.0"

--- a/src/kalshi_bot/cli.py
+++ b/src/kalshi_bot/cli.py
@@ -1,0 +1,239 @@
+"""Command-line interface for the Kalshi trading bot."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import uuid
+from dataclasses import asdict
+
+from .client import KalshiClient, KalshiClientError
+from .config import Settings, load_settings
+from .copy_trading import evaluate_copy_signals, load_copy_signals
+from .social import LeaderboardError, fetch_apify_leaderboard, load_leaderboard_file, rank_traders_for_copying
+from .strategy import choose_low_price_candidates
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run a safety-first Kalshi trading bot.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    subparsers.add_parser("balance", help="Fetch portfolio balance using signed Kalshi API auth.")
+
+    markets = subparsers.add_parser("markets", help="List currently open markets.")
+    markets.add_argument("--limit", type=int, default=10)
+
+    leaderboard = subparsers.add_parser("leaderboard", help="Fetch/filter the Kalshi social leaderboard.")
+    leaderboard.add_argument("--file", help="Read leaderboard rows from a local JSON export instead of Apify.")
+    leaderboard.add_argument("--metric", help="Leaderboard metric, e.g. projected_pnl, volume, num_markets_traded.")
+    leaderboard.add_argument("--timeframe", help="Leaderboard timeframe, e.g. daily, weekly, monthly, yearly, all_time.")
+    leaderboard.add_argument("--category", help="Optional leaderboard category filter.")
+    leaderboard.add_argument("--limit", type=int, default=10, help="Rows to print after copy filters.")
+
+    copy = subparsers.add_parser("copy", help="Evaluate explicit social copy-trading signals with safety gates.")
+    copy.add_argument("--signals-file", required=True, help="JSON file containing explicit leader/ticker/side/price signals.")
+    copy.add_argument("--leaderboard-file", help="Local leaderboard JSON export. Omit to use Apify.")
+    copy.add_argument("--max-price-cents", type=int, help="Maximum signal price to copy.")
+    copy.add_argument("--count", type=int, help="Override signal counts with this contract count.")
+    copy.add_argument("--live", action="store_true", help="Actually submit approved orders. Omit for dry-run only.")
+
+    run = subparsers.add_parser("run", help="Scan markets and optionally place one conservative order.")
+    run.add_argument("--limit", type=int, default=10, help="Number of open markets to scan.")
+    run.add_argument("--max-price-cents", type=int, help="Maximum displayed ask price to consider.")
+    run.add_argument("--count", type=int, help="Contract count to submit if live trading is enabled.")
+    run.add_argument("--live", action="store_true", help="Actually submit an order. Omit for dry-run only.")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    settings = load_settings()
+    client = KalshiClient(
+        base_url=settings.base_url,
+        api_key_id=settings.api_key_id,
+        private_key_path=settings.private_key_path,
+    )
+
+    try:
+        if args.command == "balance":
+            print(json.dumps(client.get_balance(), indent=2, sort_keys=True))
+            return 0
+
+        if args.command == "markets":
+            payload = client.get_markets(limit=args.limit)
+            print(json.dumps(payload, indent=2, sort_keys=True))
+            return 0
+
+        if args.command == "leaderboard":
+            return leaderboard_command(args, settings)
+
+        if args.command == "copy":
+            return copy_command(args, settings, client)
+
+        if args.command == "run":
+            return run_bot(args, settings, client)
+    except (KalshiClientError, LeaderboardError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    return 2
+
+
+def leaderboard_command(args: argparse.Namespace, settings: Settings) -> int:
+    traders = _load_leaderboard(args.file, settings, metric=args.metric, timeframe=args.timeframe, category=args.category)
+    qualified = rank_traders_for_copying(
+        traders,
+        min_projected_pnl_cents=settings.copy_min_projected_pnl_cents,
+        min_roi_percent=settings.copy_min_roi_percent,
+        min_markets_traded=settings.copy_min_markets_traded,
+        max_rank=settings.copy_max_rank,
+    )
+    print(
+        json.dumps(
+            {
+                "source_rows": len(traders),
+                "qualified_rows": len(qualified),
+                "copy_filters": _copy_filter_summary(settings),
+                "traders": [asdict(trader) for trader in qualified[: args.limit]],
+                "note": "Leaderboard rows are performance context only; use explicit public signals for copy trades.",
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+def copy_command(args: argparse.Namespace, settings: Settings, client: KalshiClient) -> int:
+    max_price_cents = args.max_price_cents or settings.default_max_price_cents
+    signals = load_copy_signals(args.signals_file)
+    if args.count is not None:
+        signals = [signal.__class__(**{**asdict(signal), "count": args.count}) for signal in signals]
+    leaderboard = _load_leaderboard(args.leaderboard_file, settings, metric=None, timeframe=None, category=None)
+    market_lookup = _fetch_signal_markets(client, signals)
+    decisions = evaluate_copy_signals(
+        signals,
+        leaderboard,
+        market_lookup,
+        min_projected_pnl_cents=settings.copy_min_projected_pnl_cents,
+        min_roi_percent=settings.copy_min_roi_percent,
+        min_markets_traded=settings.copy_min_markets_traded,
+        max_rank=settings.copy_max_rank,
+        max_price_cents=max_price_cents,
+        min_volume=settings.copy_min_market_volume,
+        allowed_categories=set(settings.copy_allowed_categories) or None,
+    )
+    dry_run = settings.dry_run or not args.live
+    print(
+        json.dumps(
+            {
+                "dry_run": dry_run,
+                "copy_filters": {**_copy_filter_summary(settings), "max_price_cents": max_price_cents},
+                "decisions": [
+                    {"signal": asdict(decision.signal), "approved": decision.approved, "reasons": decision.reasons}
+                    for decision in decisions
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    approved = [decision for decision in decisions if decision.approved]
+    if dry_run:
+        print("Dry run only. Re-run with --live and KALSHI_DRY_RUN=false to submit approved copy orders.")
+        return 0
+    for decision in approved:
+        signal = decision.signal
+        response = client.place_event_order(
+            ticker=signal.ticker,
+            side=signal.side,
+            count=signal.count,
+            price_dollars=signal.price_dollars,
+            client_order_id=str(uuid.uuid4()),
+        )
+        print(json.dumps(response, indent=2, sort_keys=True))
+    return 0
+
+
+def run_bot(args: argparse.Namespace, settings: Settings, client: KalshiClient) -> int:
+    max_price_cents = args.max_price_cents or settings.default_max_price_cents
+    count = args.count or settings.default_order_count
+    markets_payload = client.get_markets(limit=args.limit, status="open")
+    markets = markets_payload.get("markets", [])
+    candidates = choose_low_price_candidates(markets, max_price_cents=max_price_cents)
+
+    if not candidates:
+        print(f"No candidates found at or below {max_price_cents}¢.")
+        return 0
+
+    candidate = candidates[0]
+    print(
+        json.dumps(
+            {
+                "selected": candidate.__dict__,
+                "count": count,
+                "dry_run": settings.dry_run or not args.live,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+    if settings.dry_run or not args.live:
+        print("Dry run only. Re-run with --live and KALSHI_DRY_RUN=false to submit an order.")
+        return 0
+
+    response = client.place_event_order(
+        ticker=candidate.ticker,
+        side=candidate.side,
+        count=count,
+        price_dollars=candidate.price_dollars,
+        client_order_id=str(uuid.uuid4()),
+    )
+    print(json.dumps(response, indent=2, sort_keys=True))
+    return 0
+
+
+def _load_leaderboard(
+    path: str | None,
+    settings: Settings,
+    *,
+    metric: str | None,
+    timeframe: str | None,
+    category: str | None,
+):
+    if path:
+        return load_leaderboard_file(path)
+    if not settings.apify_api_token:
+        raise LeaderboardError("Provide --leaderboard-file/--file or set APIFY_API_TOKEN for the optional Apify scraper.")
+    return fetch_apify_leaderboard(
+        api_token=settings.apify_api_token,
+        metric=metric or settings.leaderboard_metric,
+        timeframe=timeframe or settings.leaderboard_timeframe,
+        category=category if category is not None else settings.leaderboard_category,
+    )
+
+
+def _fetch_signal_markets(client: KalshiClient, signals) -> dict[str, dict]:
+    market_lookup: dict[str, dict] = {}
+    for ticker in sorted({signal.ticker for signal in signals}):
+        payload = client.get_market(ticker)
+        market_lookup[ticker] = payload.get("market", payload)
+    return market_lookup
+
+
+def _copy_filter_summary(settings: Settings) -> dict:
+    return {
+        "min_projected_pnl_cents": settings.copy_min_projected_pnl_cents,
+        "min_roi_percent": settings.copy_min_roi_percent,
+        "min_markets_traded": settings.copy_min_markets_traded,
+        "max_rank": settings.copy_max_rank,
+        "min_market_volume": settings.copy_min_market_volume,
+        "allowed_categories": sorted(settings.copy_allowed_categories),
+    }
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/kalshi_bot/cli.py
+++ b/src/kalshi_bot/cli.py
@@ -12,7 +12,7 @@ from .client import KalshiClient, KalshiClientError
 from .config import Settings, load_settings
 from .copy_trading import evaluate_copy_signals, load_copy_signals
 from .social import LeaderboardError, fetch_apify_leaderboard, load_leaderboard_file, rank_traders_for_copying
-from .strategy import choose_low_price_candidates
+from .strategy import choose_combo_prediction_candidates, choose_low_price_candidates, load_prediction_signals
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -41,6 +41,11 @@ def build_parser() -> argparse.ArgumentParser:
     run = subparsers.add_parser("run", help="Scan markets and optionally place one conservative order.")
     run.add_argument("--limit", type=int, default=10, help="Number of open markets to scan.")
     run.add_argument("--max-price-cents", type=int, help="Maximum displayed ask price to consider.")
+    run.add_argument("--strategy", choices=("low-price", "combo-prediction"), default="low-price")
+    run.add_argument("--predictions-file", help="JSON file with multiple YES-probability predictions per ticker.")
+    run.add_argument("--min-combo-signals", type=int, help="Minimum prediction signals required for combo-prediction.")
+    run.add_argument("--min-edge-cents", type=int, help="Minimum predicted edge over ask for combo-prediction.")
+    run.add_argument("--min-confidence-cents", type=int, help="Minimum combo probability required for the selected outcome.")
     run.add_argument("--count", type=int, help="Contract count to submit if live trading is enabled.")
     run.add_argument("--live", action="store_true", help="Actually submit an order. Omit for dry-run only.")
 
@@ -162,10 +167,22 @@ def run_bot(args: argparse.Namespace, settings: Settings, client: KalshiClient) 
     count = args.count or settings.default_order_count
     markets_payload = client.get_markets(limit=args.limit, status="open")
     markets = markets_payload.get("markets", [])
-    candidates = choose_low_price_candidates(markets, max_price_cents=max_price_cents)
+    if args.strategy == "combo-prediction":
+        if not args.predictions_file:
+            raise ValueError("--predictions-file is required when --strategy combo-prediction is used.")
+        candidates = choose_combo_prediction_candidates(
+            markets,
+            load_prediction_signals(args.predictions_file),
+            max_price_cents=max_price_cents,
+            min_edge_cents=args.min_edge_cents or settings.combo_min_edge_cents,
+            min_confidence_cents=args.min_confidence_cents or settings.combo_min_confidence_cents,
+            min_combo_signals=args.min_combo_signals or settings.combo_min_signals,
+        )
+    else:
+        candidates = choose_low_price_candidates(markets, max_price_cents=max_price_cents)
 
     if not candidates:
-        print(f"No candidates found at or below {max_price_cents}¢.")
+        print(f"No {args.strategy} candidates found at or below {max_price_cents}¢.")
         return 0
 
     candidate = candidates[0]
@@ -173,6 +190,7 @@ def run_bot(args: argparse.Namespace, settings: Settings, client: KalshiClient) 
         json.dumps(
             {
                 "selected": candidate.__dict__,
+                "strategy": args.strategy,
                 "count": count,
                 "dry_run": settings.dry_run or not args.live,
             },

--- a/src/kalshi_bot/client.py
+++ b/src/kalshi_bot/client.py
@@ -1,0 +1,145 @@
+"""Minimal Kalshi REST client with RSA-PSS request signing."""
+
+from __future__ import annotations
+
+import base64
+import datetime as dt
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+
+HttpMethod = str
+
+
+class KalshiClientError(RuntimeError):
+    """Raised when Kalshi returns an unsuccessful response."""
+
+
+class MissingCredentialsError(KalshiClientError):
+    """Raised when an authenticated endpoint is called without credentials."""
+
+
+class KalshiClient:
+    """Small REST client for Kalshi's Trade API v2."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        api_key_id: str | None = None,
+        private_key_path: str | Path | None = None,
+        timeout_seconds: float = 15.0,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.api_key_id = api_key_id
+        self.private_key_path = Path(private_key_path).expanduser() if private_key_path else None
+        self.timeout_seconds = timeout_seconds
+        self._private_key: Any | None = None
+
+    def get_markets(self, *, limit: int = 10, status: str = "open") -> dict[str, Any]:
+        return self.request("GET", "/markets", params={"limit": limit, "status": status}, auth=False)
+
+    def get_market(self, ticker: str) -> dict[str, Any]:
+        return self.request("GET", f"/markets/{ticker}", auth=False)
+
+    def get_orderbook(self, ticker: str) -> dict[str, Any]:
+        return self.request("GET", f"/markets/{ticker}/orderbook", auth=False)
+
+    def get_balance(self) -> dict[str, Any]:
+        return self.request("GET", "/portfolio/balance", auth=True)
+
+    def list_orders(self, *, limit: int = 50) -> dict[str, Any]:
+        return self.request("GET", "/portfolio/orders", params={"limit": limit}, auth=True)
+
+    def place_event_order(
+        self,
+        *,
+        ticker: str,
+        side: str,
+        count: int,
+        price_dollars: str,
+        client_order_id: str,
+    ) -> dict[str, Any]:
+        """Submit an event-market order with Kalshi's V2 order shape."""
+
+        payload = {
+            "ticker": ticker,
+            "side": side,
+            "count": f"{count:.2f}",
+            "price": price_dollars,
+            "time_in_force": "good_till_canceled",
+            "self_trade_prevention_type": "taker_at_cross",
+            "client_order_id": client_order_id,
+        }
+        return self.request("POST", "/portfolio/events/orders", json=payload, auth=True)
+
+    def request(
+        self,
+        method: HttpMethod,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json: dict[str, Any] | None = None,
+        auth: bool,
+    ) -> dict[str, Any]:
+        import requests
+
+        url = f"{self.base_url}{path}"
+        headers = self._auth_headers(method, path) if auth else {}
+        response = requests.request(
+            method,
+            url,
+            params=params,
+            json=json,
+            headers=headers,
+            timeout=self.timeout_seconds,
+        )
+        if response.status_code >= 400:
+            raise KalshiClientError(f"Kalshi API error {response.status_code}: {response.text}")
+        return response.json()
+
+    def _auth_headers(self, method: HttpMethod, path: str) -> dict[str, str]:
+        if not self.api_key_id or not self.private_key_path:
+            raise MissingCredentialsError(
+                "KALSHI_API_KEY_ID and KALSHI_PRIVATE_KEY_PATH are required for authenticated requests."
+            )
+
+        timestamp = str(int(dt.datetime.now(tz=dt.UTC).timestamp() * 1000))
+        sign_path = urlparse(f"{self.base_url}{path}").path
+        signature = self.sign_request(timestamp, method.upper(), sign_path)
+        return {
+            "KALSHI-ACCESS-KEY": self.api_key_id,
+            "KALSHI-ACCESS-SIGNATURE": signature,
+            "KALSHI-ACCESS-TIMESTAMP": timestamp,
+            "Content-Type": "application/json",
+        }
+
+    def sign_request(self, timestamp: str, method: HttpMethod, path: str) -> str:
+        from cryptography.hazmat.primitives import hashes
+        from cryptography.hazmat.primitives.asymmetric import padding
+
+        path_without_query = path.split("?", 1)[0]
+        message = f"{timestamp}{method.upper()}{path_without_query}".encode("utf-8")
+        signature = self._load_private_key().sign(
+            message,
+            padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.DIGEST_LENGTH),
+            hashes.SHA256(),
+        )
+        return base64.b64encode(signature).decode("utf-8")
+
+    def _load_private_key(self) -> Any:
+        from cryptography.hazmat.backends import default_backend
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+
+        if self._private_key is not None:
+            return self._private_key
+        if self.private_key_path is None:
+            raise MissingCredentialsError("KALSHI_PRIVATE_KEY_PATH is required for request signing.")
+        with self.private_key_path.open("rb") as key_file:
+            key = serialization.load_pem_private_key(key_file.read(), password=None, backend=default_backend())
+        if not isinstance(key, rsa.RSAPrivateKey):
+            raise KalshiClientError("Kalshi private key must be an RSA private key.")
+        self._private_key = key
+        return key

--- a/src/kalshi_bot/config.py
+++ b/src/kalshi_bot/config.py
@@ -20,6 +20,9 @@ class Settings:
     dry_run: bool
     default_order_count: int
     default_max_price_cents: int
+    combo_min_signals: int
+    combo_min_edge_cents: int
+    combo_min_confidence_cents: int
     apify_api_token: str | None
     leaderboard_metric: str
     leaderboard_timeframe: str
@@ -86,6 +89,9 @@ def load_settings(env_file: str | os.PathLike[str] | None = ".env") -> Settings:
         dry_run=_bool_from_env(os.getenv("KALSHI_DRY_RUN"), default=True),
         default_order_count=int(os.getenv("KALSHI_DEFAULT_ORDER_COUNT", "1")),
         default_max_price_cents=int(os.getenv("KALSHI_DEFAULT_MAX_PRICE_CENTS", "1")),
+        combo_min_signals=int(os.getenv("KALSHI_COMBO_MIN_SIGNALS", "2")),
+        combo_min_edge_cents=int(os.getenv("KALSHI_COMBO_MIN_EDGE_CENTS", "3")),
+        combo_min_confidence_cents=int(os.getenv("KALSHI_COMBO_MIN_CONFIDENCE_CENTS", "55")),
         apify_api_token=os.getenv("APIFY_API_TOKEN"),
         leaderboard_metric=os.getenv("KALSHI_LEADERBOARD_METRIC", "projected_pnl"),
         leaderboard_timeframe=os.getenv("KALSHI_LEADERBOARD_TIMEFRAME", "monthly"),

--- a/src/kalshi_bot/config.py
+++ b/src/kalshi_bot/config.py
@@ -1,0 +1,101 @@
+"""Configuration loading for the Kalshi trading bot."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+DEMO_REST_URL = "https://external-api.demo.kalshi.co/trade-api/v2"
+PRODUCTION_REST_URL = "https://external-api.kalshi.com/trade-api/v2"
+
+
+@dataclass(frozen=True)
+class Settings:
+    """Runtime settings sourced from environment variables."""
+
+    api_key_id: str | None
+    private_key_path: Path | None
+    base_url: str
+    dry_run: bool
+    default_order_count: int
+    default_max_price_cents: int
+    apify_api_token: str | None
+    leaderboard_metric: str
+    leaderboard_timeframe: str
+    leaderboard_category: str
+    copy_min_projected_pnl_cents: int
+    copy_min_roi_percent: float | None
+    copy_min_markets_traded: int
+    copy_max_rank: int | None
+    copy_min_market_volume: int
+    copy_allowed_categories: frozenset[str]
+
+    @property
+    def has_credentials(self) -> bool:
+        return bool(self.api_key_id and self.private_key_path)
+
+
+def _bool_from_env(value: str | None, *, default: bool) -> bool:
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _load_env_file(env_file: str | os.PathLike[str] | None) -> None:
+    if not env_file:
+        return
+    path = Path(env_file)
+    if not path.exists():
+        return
+    for raw_line in path.read_text().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        os.environ.setdefault(key, value)
+
+
+def _optional_int(value: str | None) -> int | None:
+    if value in (None, ""):
+        return None
+    return int(value)
+
+
+def _optional_float(value: str | None) -> float | None:
+    if value in (None, ""):
+        return None
+    return float(value)
+
+
+def load_settings(env_file: str | os.PathLike[str] | None = ".env") -> Settings:
+    """Load settings from ``env_file`` and process environment variables."""
+
+    _load_env_file(env_file)
+
+    private_key_path = os.getenv("KALSHI_PRIVATE_KEY_PATH")
+    environment = os.getenv("KALSHI_ENV", "demo").strip().lower()
+    default_base_url = PRODUCTION_REST_URL if environment == "production" else DEMO_REST_URL
+
+    return Settings(
+        api_key_id=os.getenv("KALSHI_API_KEY_ID"),
+        private_key_path=Path(private_key_path).expanduser() if private_key_path else None,
+        base_url=os.getenv("KALSHI_BASE_URL", default_base_url).rstrip("/"),
+        dry_run=_bool_from_env(os.getenv("KALSHI_DRY_RUN"), default=True),
+        default_order_count=int(os.getenv("KALSHI_DEFAULT_ORDER_COUNT", "1")),
+        default_max_price_cents=int(os.getenv("KALSHI_DEFAULT_MAX_PRICE_CENTS", "1")),
+        apify_api_token=os.getenv("APIFY_API_TOKEN"),
+        leaderboard_metric=os.getenv("KALSHI_LEADERBOARD_METRIC", "projected_pnl"),
+        leaderboard_timeframe=os.getenv("KALSHI_LEADERBOARD_TIMEFRAME", "monthly"),
+        leaderboard_category=os.getenv("KALSHI_LEADERBOARD_CATEGORY", ""),
+        copy_min_projected_pnl_cents=int(os.getenv("KALSHI_COPY_MIN_PROJECTED_PNL_CENTS", "10000")),
+        copy_min_roi_percent=_optional_float(os.getenv("KALSHI_COPY_MIN_ROI_PERCENT")),
+        copy_min_markets_traded=int(os.getenv("KALSHI_COPY_MIN_MARKETS_TRADED", "5")),
+        copy_max_rank=_optional_int(os.getenv("KALSHI_COPY_MAX_RANK", "25")),
+        copy_min_market_volume=int(os.getenv("KALSHI_COPY_MIN_MARKET_VOLUME", "0")),
+        copy_allowed_categories=frozenset(
+            item.strip() for item in os.getenv("KALSHI_COPY_ALLOWED_CATEGORIES", "").split(",") if item.strip()
+        ),
+    )

--- a/src/kalshi_bot/copy_trading.py
+++ b/src/kalshi_bot/copy_trading.py
@@ -1,0 +1,139 @@
+"""Safety checks for leaderboard-informed copy-trading signals."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .social import LeaderboardTrader, rank_traders_for_copying
+
+
+@dataclass(frozen=True)
+class CopySignal:
+    """A proposed trade from a public/social signal source."""
+
+    leader_handle: str
+    ticker: str
+    side: str
+    price_cents: int
+    count: int
+    reason: str
+
+    @property
+    def price_dollars(self) -> str:
+        return f"{self.price_cents / 100:.4f}"
+
+
+@dataclass(frozen=True)
+class CopyDecision:
+    """The result of evaluating a potential copy trade."""
+
+    signal: CopySignal
+    approved: bool
+    reasons: tuple[str, ...]
+
+
+def load_copy_signals(path: str | Path) -> list[CopySignal]:
+    """Load copy-trading signals from a JSON file.
+
+    Expected shape: either a list of objects or ``{"signals": [...]}``. This makes
+    copy trading explicit; the bot will not infer hidden/private trades from a
+    leaderboard row alone.
+    """
+
+    payload = json.loads(Path(path).read_text())
+    rows = payload.get("signals", payload) if isinstance(payload, dict) else payload
+    if not isinstance(rows, list):
+        raise ValueError("Signals JSON must be a list or an object with a 'signals' list.")
+    signals: list[CopySignal] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        signals.append(
+            CopySignal(
+                leader_handle=str(row["leader_handle"]),
+                ticker=str(row["ticker"]),
+                side=str(row.get("side", "bid")),
+                price_cents=_cents(row["price_cents"]),
+                count=int(row.get("count", 1)),
+                reason=str(row.get("reason", "external copy-trading signal")),
+            )
+        )
+    return signals
+
+
+def evaluate_copy_signals(
+    signals: list[CopySignal],
+    leaderboard: list[LeaderboardTrader],
+    market_lookup: dict[str, dict[str, Any]],
+    *,
+    min_projected_pnl_cents: int,
+    min_roi_percent: float | None,
+    min_markets_traded: int,
+    max_rank: int | None,
+    max_price_cents: int,
+    min_volume: int,
+    allowed_categories: set[str] | None,
+) -> list[CopyDecision]:
+    """Approve only signals that pass leaderboard, price, liquidity, and category gates."""
+
+    qualified = {
+        trader.handle.lower(): trader
+        for trader in rank_traders_for_copying(
+            leaderboard,
+            min_projected_pnl_cents=min_projected_pnl_cents,
+            min_roi_percent=min_roi_percent,
+            min_markets_traded=min_markets_traded,
+            max_rank=max_rank,
+        )
+    }
+    decisions: list[CopyDecision] = []
+    for signal in signals:
+        reasons: list[str] = []
+        trader = qualified.get(signal.leader_handle.lower())
+        market = market_lookup.get(signal.ticker, {})
+
+        if trader is None:
+            reasons.append("leader does not meet configured leaderboard performance filters")
+        if signal.price_cents > max_price_cents:
+            reasons.append(f"signal price {signal.price_cents}¢ exceeds max {max_price_cents}¢")
+        if signal.count <= 0:
+            reasons.append("signal count must be positive")
+
+        volume = _market_int(market, "volume", "volume_24h", "notional_volume")
+        if volume is not None and volume < min_volume:
+            reasons.append(f"market volume {volume} is below min {min_volume}")
+
+        category = _market_text(market, "category", "event_category", "series_ticker")
+        if allowed_categories and (category or "").lower() not in {item.lower() for item in allowed_categories}:
+            reasons.append(f"market category {category or 'unknown'} is not allowed")
+
+        if not reasons:
+            reasons.append("leaderboard, price, liquidity, and category filters passed")
+        decisions.append(CopyDecision(signal=signal, approved=len(reasons) == 1 and reasons[0].endswith("passed"), reasons=tuple(reasons)))
+    return decisions
+
+
+def _cents(value: object) -> int:
+    return int(float(str(value).replace("¢", "").replace("$", "")))
+
+
+def _market_int(market: dict[str, Any], *names: str) -> int | None:
+    for name in names:
+        value = market.get(name)
+        if value not in (None, ""):
+            try:
+                return int(float(str(value).replace(",", "")))
+            except ValueError:
+                return None
+    return None
+
+
+def _market_text(market: dict[str, Any], *names: str) -> str | None:
+    for name in names:
+        value = market.get(name)
+        if value not in (None, ""):
+            return str(value)
+    return None

--- a/src/kalshi_bot/social.py
+++ b/src/kalshi_bot/social.py
@@ -1,0 +1,188 @@
+"""Kalshi social leaderboard ingestion helpers.
+
+Kalshi's public Trade API does not expose trader identities or a native copy-trading
+feed. This module keeps leaderboard lookup explicit and pluggable: use a local
+JSON export for tests/manual review, or an Apify actor token if you choose to use
+that third-party scraper.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+class LeaderboardError(RuntimeError):
+    """Raised when leaderboard data cannot be loaded or normalized."""
+
+
+@dataclass(frozen=True)
+class LeaderboardTrader:
+    """A normalized trader row from a Kalshi social leaderboard source."""
+
+    handle: str
+    rank: int | None
+    projected_pnl_cents: int | None
+    roi_percent: float | None
+    volume_cents: int | None
+    markets_traded: int | None
+    category: str | None
+    timeframe: str | None
+    source: str
+
+    @property
+    def projected_pnl_dollars(self) -> float | None:
+        if self.projected_pnl_cents is None:
+            return None
+        return self.projected_pnl_cents / 100
+
+
+def load_leaderboard_file(path: str | Path) -> list[LeaderboardTrader]:
+    """Load leaderboard rows from a JSON file exported by a scraper or manually saved."""
+
+    payload = json.loads(Path(path).read_text())
+    rows = payload.get("items", payload) if isinstance(payload, dict) else payload
+    if not isinstance(rows, list):
+        raise LeaderboardError("Leaderboard JSON must be a list or an object with an 'items' list.")
+    return normalize_leaderboard_rows(rows, source=str(path))
+
+
+def fetch_apify_leaderboard(
+    *,
+    api_token: str,
+    metric: str,
+    timeframe: str,
+    category: str = "",
+    timeout_seconds: float = 120.0,
+) -> list[LeaderboardTrader]:
+    """Fetch Kalshi leaderboard rows via the optional Apify community actor.
+
+    The actor is third-party infrastructure, so callers must provide their own
+    Apify token and should review the actor's terms/pricing before use.
+    """
+
+    import requests
+
+    response = requests.post(
+        "https://api.apify.com/v2/acts/saswave~kalshi-leaderboard-scraper/run-sync-get-dataset-items",
+        params={"token": api_token},
+        json={"name": metric, "time": timeframe, "category": category},
+        timeout=timeout_seconds,
+    )
+    if response.status_code >= 400:
+        raise LeaderboardError(f"Apify leaderboard fetch failed {response.status_code}: {response.text}")
+    payload = response.json()
+    if not isinstance(payload, list):
+        raise LeaderboardError("Apify leaderboard response was not a list of rows.")
+    return normalize_leaderboard_rows(payload, source="apify:saswave/kalshi-leaderboard-scraper")
+
+
+def normalize_leaderboard_rows(rows: list[dict[str, Any]], *, source: str) -> list[LeaderboardTrader]:
+    """Normalize likely leaderboard field names into ``LeaderboardTrader`` objects."""
+
+    traders: list[LeaderboardTrader] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        handle = _first_text(row, "handle", "username", "user", "name", "trader", "display_name")
+        if not handle:
+            continue
+        traders.append(
+            LeaderboardTrader(
+                handle=handle,
+                rank=_first_int(row, "rank", "position", "place"),
+                projected_pnl_cents=_money_to_cents(
+                    _first_value(row, "projected_pnl", "pnl", "profit", "net_profit", "projectedPnl")
+                ),
+                roi_percent=_percent_to_float(_first_value(row, "roi", "roi_percent", "return", "return_percent")),
+                volume_cents=_money_to_cents(_first_value(row, "volume", "total_volume", "volume_traded")),
+                markets_traded=_first_int(row, "num_markets_traded", "markets_traded", "markets", "market_count"),
+                category=_first_text(row, "category", "section"),
+                timeframe=_first_text(row, "timeframe", "time", "date_range"),
+                source=source,
+            )
+        )
+    return traders
+
+
+def rank_traders_for_copying(
+    traders: list[LeaderboardTrader],
+    *,
+    min_projected_pnl_cents: int,
+    min_roi_percent: float | None = None,
+    min_markets_traded: int = 0,
+    max_rank: int | None = None,
+) -> list[LeaderboardTrader]:
+    """Filter leaderboard rows to traders with enough public performance history."""
+
+    qualified: list[LeaderboardTrader] = []
+    for trader in traders:
+        if trader.projected_pnl_cents is None or trader.projected_pnl_cents < min_projected_pnl_cents:
+            continue
+        if min_roi_percent is not None and (trader.roi_percent is None or trader.roi_percent < min_roi_percent):
+            continue
+        if trader.markets_traded is not None and trader.markets_traded < min_markets_traded:
+            continue
+        if max_rank is not None and trader.rank is not None and trader.rank > max_rank:
+            continue
+        qualified.append(trader)
+    return sorted(qualified, key=lambda item: (item.rank is None, item.rank or 999_999, -(item.projected_pnl_cents or 0)))
+
+
+def _first_value(row: dict[str, Any], *names: str) -> Any:
+    lowered = {key.lower(): value for key, value in row.items()}
+    for name in names:
+        if name in row:
+            return row[name]
+        if name.lower() in lowered:
+            return lowered[name.lower()]
+    return None
+
+
+def _first_text(row: dict[str, Any], *names: str) -> str | None:
+    value = _first_value(row, *names)
+    if value in (None, ""):
+        return None
+    return str(value).strip()
+
+
+def _first_int(row: dict[str, Any], *names: str) -> int | None:
+    value = _first_value(row, *names)
+    if value in (None, ""):
+        return None
+    try:
+        return int(float(str(value).replace(",", "")))
+    except ValueError:
+        return None
+
+
+def _money_to_cents(value: Any) -> int | None:
+    if value in (None, ""):
+        return None
+    if isinstance(value, int | float):
+        return round(float(value) * 100)
+    text = str(value).strip().replace(",", "")
+    multiplier = 1.0
+    if text.endswith("K") or text.endswith("k"):
+        multiplier = 1_000.0
+        text = text[:-1]
+    elif text.endswith("M") or text.endswith("m"):
+        multiplier = 1_000_000.0
+        text = text[:-1]
+    text = text.replace("$", "").replace("¢", "")
+    try:
+        return round(float(text) * multiplier * 100)
+    except ValueError:
+        return None
+
+
+def _percent_to_float(value: Any) -> float | None:
+    if value in (None, ""):
+        return None
+    text = str(value).strip().replace(",", "").replace("%", "")
+    try:
+        return float(text)
+    except ValueError:
+        return None

--- a/src/kalshi_bot/strategy.py
+++ b/src/kalshi_bot/strategy.py
@@ -1,0 +1,63 @@
+"""Simple, conservative trading strategy helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TradeCandidate:
+    ticker: str
+    title: str
+    side: str
+    price_cents: int
+    reason: str
+
+    @property
+    def price_dollars(self) -> str:
+        return f"{self.price_cents / 100:.4f}"
+
+
+def choose_low_price_candidates(
+    markets: list[dict],
+    *,
+    max_price_cents: int,
+    side: str = "bid",
+) -> list[TradeCandidate]:
+    """Pick open markets with a displayed yes/no ask no higher than ``max_price_cents``.
+
+    This is intentionally not financial advice or a profitable strategy. It is a
+    transparent starter rule that lets the bot run safely in dry-run mode while
+    you replace it with your own model.
+    """
+
+    candidates: list[TradeCandidate] = []
+    for market in markets:
+        ticker = str(market.get("ticker", ""))
+        title = str(market.get("title", ticker))
+        yes_ask = _coerce_cents(market.get("yes_ask"))
+        no_ask = _coerce_cents(market.get("no_ask"))
+        ask_prices = [price for price in (yes_ask, no_ask) if price is not None]
+        if not ticker or not ask_prices:
+            continue
+        best_price = min(ask_prices)
+        if best_price <= max_price_cents:
+            candidates.append(
+                TradeCandidate(
+                    ticker=ticker,
+                    title=title,
+                    side=side,
+                    price_cents=best_price,
+                    reason=f"lowest displayed ask ({best_price}¢) is <= max ({max_price_cents}¢)",
+                )
+            )
+    return candidates
+
+
+def _coerce_cents(value: object) -> int | None:
+    if value in (None, ""):
+        return None
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return None

--- a/src/kalshi_bot/strategy.py
+++ b/src/kalshi_bot/strategy.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
 
 
 @dataclass(frozen=True)
@@ -12,10 +15,25 @@ class TradeCandidate:
     side: str
     price_cents: int
     reason: str
+    outcome: str | None = None
+    predicted_probability_cents: int | None = None
+    edge_cents: int | None = None
+    combo_signal_count: int = 0
+    combo_sources: tuple[str, ...] = ()
 
     @property
     def price_dollars(self) -> str:
         return f"{self.price_cents / 100:.4f}"
+
+
+@dataclass(frozen=True)
+class PredictionSignal:
+    """One prediction input for a market, normalized to a YES probability."""
+
+    ticker: str
+    probability_cents: int
+    source: str
+    weight: float = 1.0
 
 
 def choose_low_price_candidates(
@@ -54,6 +72,189 @@ def choose_low_price_candidates(
     return candidates
 
 
+def load_prediction_signals(path: str | Path) -> dict[str, list[PredictionSignal]]:
+    """Load combo prediction inputs from JSON.
+
+    Accepted shapes are ``[{...}]``, ``{"predictions": [{...}]}``, or a mapping
+    of ticker to one or more probability entries. Probabilities may be expressed
+    as cents/percentage points (``62`` or ``"62%"``) or decimals (``0.62``).
+    """
+
+    payload = json.loads(Path(path).read_text())
+    rows: list[dict[str, Any]] = []
+    if isinstance(payload, dict) and "predictions" in payload:
+        raw_rows = payload["predictions"]
+        if not isinstance(raw_rows, list):
+            raise ValueError("predictions must be a list")
+        rows = [row for row in raw_rows if isinstance(row, dict)]
+    elif isinstance(payload, list):
+        rows = [row for row in payload if isinstance(row, dict)]
+    elif isinstance(payload, dict):
+        for ticker, value in payload.items():
+            entries = value if isinstance(value, list) else [value]
+            for index, entry in enumerate(entries):
+                if isinstance(entry, dict):
+                    rows.append({"ticker": ticker, **entry})
+                else:
+                    rows.append({"ticker": ticker, "probability_cents": entry, "source": f"{ticker}:{index}"})
+    else:
+        raise ValueError("Prediction JSON must be a list, mapping, or object with a 'predictions' list.")
+
+    grouped: dict[str, list[PredictionSignal]] = {}
+    for row in rows:
+        ticker = str(row.get("ticker", "")).strip()
+        if not ticker:
+            continue
+        probability = _prediction_probability(row)
+        if probability is None:
+            continue
+        source = str(row.get("source") or row.get("model") or row.get("name") or "prediction")
+        weight = _coerce_float(row.get("weight"), default=1.0)
+        if weight <= 0:
+            continue
+        signal = PredictionSignal(ticker=ticker, probability_cents=probability, source=source, weight=weight)
+        grouped.setdefault(ticker, []).append(signal)
+    return grouped
+
+
+def choose_combo_prediction_candidates(
+    markets: list[dict],
+    prediction_signals: dict[str, list[PredictionSignal]],
+    *,
+    max_price_cents: int,
+    min_edge_cents: int,
+    min_confidence_cents: int,
+    min_combo_signals: int,
+    side: str = "bid",
+) -> list[TradeCandidate]:
+    """Pick trades when a combination of prediction signals implies enough edge.
+
+    The strategy treats each signal as a YES-probability estimate, combines the
+    configured signals with a weighted average, and only considers a market when
+    at least ``min_combo_signals`` independent inputs agree. It then compares the
+    combo-implied YES/NO probability to the current displayed ask and keeps the
+    side with enough confidence and edge.
+    """
+
+    candidates: list[TradeCandidate] = []
+    for market in markets:
+        ticker = str(market.get("ticker", ""))
+        title = str(market.get("title", ticker))
+        if not ticker:
+            continue
+        signals = prediction_signals.get(ticker, [])
+        if len(signals) < min_combo_signals:
+            continue
+        yes_probability = _weighted_probability(signals)
+        yes_ask = _coerce_cents(market.get("yes_ask"))
+        no_ask = _coerce_cents(market.get("no_ask"))
+        market_candidates: list[TradeCandidate] = []
+
+        if yes_ask is not None and yes_ask <= max_price_cents:
+            yes_edge = yes_probability - yes_ask
+            if yes_probability >= min_confidence_cents and yes_edge >= min_edge_cents:
+                market_candidates.append(
+                    _combo_candidate(
+                        ticker=ticker,
+                        title=title,
+                        side=side,
+                        outcome="yes",
+                        price_cents=yes_ask,
+                        probability_cents=yes_probability,
+                        edge_cents=yes_edge,
+                        signals=signals,
+                        min_edge_cents=min_edge_cents,
+                    )
+                )
+
+        no_probability = 100 - yes_probability
+        if no_ask is not None and no_ask <= max_price_cents:
+            no_edge = no_probability - no_ask
+            if no_probability >= min_confidence_cents and no_edge >= min_edge_cents:
+                market_candidates.append(
+                    _combo_candidate(
+                        ticker=ticker,
+                        title=title,
+                        side=side,
+                        outcome="no",
+                        price_cents=no_ask,
+                        probability_cents=no_probability,
+                        edge_cents=no_edge,
+                        signals=signals,
+                        min_edge_cents=min_edge_cents,
+                    )
+                )
+
+        if market_candidates:
+            candidates.append(max(market_candidates, key=lambda candidate: candidate.edge_cents or 0))
+
+    return sorted(candidates, key=lambda candidate: (-(candidate.edge_cents or 0), candidate.price_cents, candidate.ticker))
+
+
+def _combo_candidate(
+    *,
+    ticker: str,
+    title: str,
+    side: str,
+    outcome: str,
+    price_cents: int,
+    probability_cents: int,
+    edge_cents: int,
+    signals: list[PredictionSignal],
+    min_edge_cents: int,
+) -> TradeCandidate:
+    sources = tuple(signal.source for signal in signals)
+    return TradeCandidate(
+        ticker=ticker,
+        title=title,
+        side=side,
+        price_cents=price_cents,
+        outcome=outcome,
+        predicted_probability_cents=probability_cents,
+        edge_cents=edge_cents,
+        combo_signal_count=len(signals),
+        combo_sources=sources,
+        reason=(
+            f"{len(signals)} prediction signals imply {probability_cents}¢ {outcome.upper()} probability; "
+            f"ask is {price_cents}¢ for {edge_cents}¢ edge >= min {min_edge_cents}¢"
+        ),
+    )
+
+
+def _prediction_probability(row: dict[str, Any]) -> int | None:
+    for key in (
+        "yes_probability_cents",
+        "probability_cents",
+        "yes_probability",
+        "probability",
+        "projected_probability",
+        "model_probability",
+    ):
+        if key in row:
+            return _coerce_probability_cents(row[key])
+    return None
+
+
+def _weighted_probability(signals: list[PredictionSignal]) -> int:
+    total_weight = sum(signal.weight for signal in signals)
+    return round(sum(signal.probability_cents * signal.weight for signal in signals) / total_weight)
+
+
+def _coerce_probability_cents(value: object) -> int | None:
+    if value in (None, ""):
+        return None
+    text = str(value).strip().replace("%", "")
+    try:
+        number = float(text)
+    except (TypeError, ValueError):
+        return None
+    if 0 <= number <= 1:
+        number *= 100
+    if not 0 <= number <= 100:
+        return None
+    return round(number)
+
+
 def _coerce_cents(value: object) -> int | None:
     if value in (None, ""):
         return None
@@ -61,3 +262,12 @@ def _coerce_cents(value: object) -> int | None:
         return int(float(value))
     except (TypeError, ValueError):
         return None
+
+
+def _coerce_float(value: object, *, default: float) -> float:
+    if value in (None, ""):
+        return default
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,59 @@
+import pytest
+
+from kalshi_bot.client import KalshiClient, MissingCredentialsError
+
+
+def test_auth_headers_require_credentials():
+    client = KalshiClient(base_url="https://external-api.demo.kalshi.co/trade-api/v2")
+
+    with pytest.raises(MissingCredentialsError):
+        client._auth_headers("GET", "/portfolio/balance")
+
+
+def test_v2_event_order_payload(monkeypatch):
+    client = KalshiClient(base_url="https://external-api.demo.kalshi.co/trade-api/v2")
+    captured = {}
+
+    def fake_request(method, path, *, params=None, json=None, auth=False):
+        captured.update(method=method, path=path, json=json, auth=auth)
+        return {"order": {"client_order_id": json["client_order_id"]}}
+
+    monkeypatch.setattr(client, "request", fake_request)
+
+    response = client.place_event_order(
+        ticker="TEST-MARKET",
+        side="bid",
+        count=1,
+        price_dollars="0.0100",
+        client_order_id="client-1",
+    )
+
+    assert response["order"]["client_order_id"] == "client-1"
+    assert captured == {
+        "method": "POST",
+        "path": "/portfolio/events/orders",
+        "json": {
+            "ticker": "TEST-MARKET",
+            "side": "bid",
+            "count": "1.00",
+            "price": "0.0100",
+            "time_in_force": "good_till_canceled",
+            "self_trade_prevention_type": "taker_at_cross",
+            "client_order_id": "client-1",
+        },
+        "auth": True,
+    }
+
+
+def test_get_market_uses_public_market_endpoint(monkeypatch):
+    client = KalshiClient(base_url="https://external-api.demo.kalshi.co/trade-api/v2")
+    captured = {}
+
+    def fake_request(method, path, *, params=None, json=None, auth=False):
+        captured.update(method=method, path=path, auth=auth)
+        return {"market": {"ticker": "TEST"}}
+
+    monkeypatch.setattr(client, "request", fake_request)
+
+    assert client.get_market("TEST") == {"market": {"ticker": "TEST"}}
+    assert captured == {"method": "GET", "path": "/markets/TEST", "auth": False}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+from kalshi_bot.config import DEMO_REST_URL, PRODUCTION_REST_URL, load_settings
+
+
+def test_load_settings_defaults_to_demo_and_dry_run(tmp_path, monkeypatch):
+    monkeypatch.delenv("KALSHI_ENV", raising=False)
+    monkeypatch.delenv("KALSHI_API_KEY_ID", raising=False)
+    settings = load_settings(env_file=tmp_path / "missing.env")
+
+    assert settings.base_url == DEMO_REST_URL
+    assert settings.dry_run is True
+    assert settings.has_credentials is False
+
+
+def test_load_settings_supports_production(tmp_path, monkeypatch):
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "KALSHI_ENV=production\n"
+        "KALSHI_API_KEY_ID=abc\n"
+        "KALSHI_PRIVATE_KEY_PATH=~/kalshi.key\n"
+        "KALSHI_DRY_RUN=false\n"
+    )
+
+    settings = load_settings(env_file=env_file)
+
+    assert settings.base_url == PRODUCTION_REST_URL
+    assert settings.api_key_id == "abc"
+    assert settings.private_key_path == Path("~/kalshi.key").expanduser()
+    assert settings.dry_run is False

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,6 +11,9 @@ def test_load_settings_defaults_to_demo_and_dry_run(tmp_path, monkeypatch):
     assert settings.base_url == DEMO_REST_URL
     assert settings.dry_run is True
     assert settings.has_credentials is False
+    assert settings.combo_min_signals == 2
+    assert settings.combo_min_edge_cents == 3
+    assert settings.combo_min_confidence_cents == 55
 
 
 def test_load_settings_supports_production(tmp_path, monkeypatch):
@@ -20,6 +23,9 @@ def test_load_settings_supports_production(tmp_path, monkeypatch):
         "KALSHI_API_KEY_ID=abc\n"
         "KALSHI_PRIVATE_KEY_PATH=~/kalshi.key\n"
         "KALSHI_DRY_RUN=false\n"
+        "KALSHI_COMBO_MIN_SIGNALS=3\n"
+        "KALSHI_COMBO_MIN_EDGE_CENTS=7\n"
+        "KALSHI_COMBO_MIN_CONFIDENCE_CENTS=60\n"
     )
 
     settings = load_settings(env_file=env_file)
@@ -28,3 +34,6 @@ def test_load_settings_supports_production(tmp_path, monkeypatch):
     assert settings.api_key_id == "abc"
     assert settings.private_key_path == Path("~/kalshi.key").expanduser()
     assert settings.dry_run is False
+    assert settings.combo_min_signals == 3
+    assert settings.combo_min_edge_cents == 7
+    assert settings.combo_min_confidence_cents == 60

--- a/tests/test_copy_trading.py
+++ b/tests/test_copy_trading.py
@@ -1,0 +1,33 @@
+from kalshi_bot.copy_trading import CopySignal, evaluate_copy_signals
+from kalshi_bot.social import normalize_leaderboard_rows
+
+
+def test_evaluate_copy_signals_requires_leader_and_market_filters():
+    leaderboard = normalize_leaderboard_rows(
+        [{"username": "sharp", "rank": 1, "projected_pnl": "$750", "roi": "20%", "markets": 12}],
+        source="fixture",
+    )
+    signals = [
+        CopySignal("sharp", "GOOD", "bid", 4, 1, "public post"),
+        CopySignal("unknown", "GOOD", "bid", 4, 1, "public post"),
+        CopySignal("sharp", "PRICEY", "bid", 20, 1, "public post"),
+    ]
+
+    decisions = evaluate_copy_signals(
+        signals,
+        leaderboard,
+        {"GOOD": {"volume": 1000, "category": "Politics"}, "PRICEY": {"volume": 1000, "category": "Politics"}},
+        min_projected_pnl_cents=50_000,
+        min_roi_percent=10,
+        min_markets_traded=5,
+        max_rank=10,
+        max_price_cents=5,
+        min_volume=100,
+        allowed_categories={"Politics"},
+    )
+
+    assert decisions[0].approved is True
+    assert decisions[1].approved is False
+    assert "leader does not meet" in decisions[1].reasons[0]
+    assert decisions[2].approved is False
+    assert "exceeds max" in decisions[2].reasons[0]

--- a/tests/test_social.py
+++ b/tests/test_social.py
@@ -1,0 +1,44 @@
+from kalshi_bot.social import normalize_leaderboard_rows, rank_traders_for_copying
+
+
+def test_normalize_leaderboard_rows_accepts_common_fields():
+    traders = normalize_leaderboard_rows(
+        [
+            {
+                "username": "sharp-one",
+                "rank": "1",
+                "projected_pnl": "$1,234.50",
+                "roi": "18.5%",
+                "volume": "$10K",
+                "num_markets_traded": "42",
+                "category": "Politics",
+            }
+        ],
+        source="fixture",
+    )
+
+    assert traders[0].handle == "sharp-one"
+    assert traders[0].projected_pnl_cents == 123450
+    assert traders[0].roi_percent == 18.5
+    assert traders[0].volume_cents == 1_000_000
+    assert traders[0].markets_traded == 42
+
+
+def test_rank_traders_for_copying_filters_profit_roi_and_history():
+    traders = normalize_leaderboard_rows(
+        [
+            {"username": "good", "rank": 2, "projected_pnl": "$500", "roi": "15%", "markets": 10},
+            {"username": "lucky", "rank": 1, "projected_pnl": "$900", "roi": "30%", "markets": 1},
+            {"username": "low-roi", "rank": 3, "projected_pnl": "$700", "roi": "2%", "markets": 20},
+        ],
+        source="fixture",
+    )
+
+    ranked = rank_traders_for_copying(
+        traders,
+        min_projected_pnl_cents=50_000,
+        min_roi_percent=10,
+        min_markets_traded=5,
+    )
+
+    assert [trader.handle for trader in ranked] == ["good"]

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -1,4 +1,9 @@
-from kalshi_bot.strategy import choose_low_price_candidates
+from kalshi_bot.strategy import (
+    PredictionSignal,
+    choose_combo_prediction_candidates,
+    choose_low_price_candidates,
+    load_prediction_signals,
+)
 
 
 def test_choose_low_price_candidates_picks_affordable_markets():
@@ -16,3 +21,47 @@ def test_choose_low_price_candidates_picks_affordable_markets():
 
 def test_choose_low_price_candidates_skips_missing_prices():
     assert choose_low_price_candidates([{"ticker": "EMPTY"}], max_price_cents=1) == []
+
+
+def test_load_prediction_signals_accepts_prediction_list(tmp_path):
+    predictions_file = tmp_path / "predictions.json"
+    predictions_file.write_text(
+        '{"predictions": ['
+        '{"ticker": "TEST", "probability": 0.62, "source": "model-a"},'
+        '{"ticker": "TEST", "probability": "66%", "source": "model-b", "weight": 2}'
+        ']}\n'
+    )
+
+    signals = load_prediction_signals(predictions_file)
+
+    assert [signal.probability_cents for signal in signals["TEST"]] == [62, 66]
+    assert signals["TEST"][1].weight == 2
+
+
+def test_choose_combo_prediction_candidates_requires_multiple_signals_and_edge():
+    markets = [
+        {"ticker": "YES-EDGE", "title": "Yes edge", "yes_ask": 55, "no_ask": 48},
+        {"ticker": "NO-EDGE", "title": "No edge", "yes_ask": 45, "no_ask": 30},
+        {"ticker": "ONE-SIGNAL", "title": "Too few signals", "yes_ask": 20, "no_ask": 80},
+    ]
+    signals = {
+        "YES-EDGE": [PredictionSignal("YES-EDGE", 70, "model-a"), PredictionSignal("YES-EDGE", 74, "model-b")],
+        "NO-EDGE": [PredictionSignal("NO-EDGE", 20, "model-a"), PredictionSignal("NO-EDGE", 24, "model-b")],
+        "ONE-SIGNAL": [PredictionSignal("ONE-SIGNAL", 90, "model-a")],
+    }
+
+    candidates = choose_combo_prediction_candidates(
+        markets,
+        signals,
+        max_price_cents=60,
+        min_edge_cents=10,
+        min_confidence_cents=60,
+        min_combo_signals=2,
+    )
+
+    assert [candidate.ticker for candidate in candidates] == ["NO-EDGE", "YES-EDGE"]
+    assert candidates[0].outcome == "no"
+    assert candidates[0].predicted_probability_cents == 78
+    assert candidates[0].edge_cents == 48
+    assert candidates[0].combo_signal_count == 2
+    assert candidates[1].outcome == "yes"

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -1,0 +1,18 @@
+from kalshi_bot.strategy import choose_low_price_candidates
+
+
+def test_choose_low_price_candidates_picks_affordable_markets():
+    markets = [
+        {"ticker": "HIGH", "title": "Too expensive", "yes_ask": 12, "no_ask": 15},
+        {"ticker": "LOW", "title": "Affordable", "yes_ask": 3, "no_ask": 7},
+    ]
+
+    candidates = choose_low_price_candidates(markets, max_price_cents=3)
+
+    assert len(candidates) == 1
+    assert candidates[0].ticker == "LOW"
+    assert candidates[0].price_dollars == "0.0300"
+
+
+def test_choose_low_price_candidates_skips_missing_prices():
+    assert choose_low_price_candidates([{"ticker": "EMPTY"}], max_price_cents=1) == []


### PR DESCRIPTION
### Motivation
- Provide a safe, auditable way to use the Kalshi social leaderboard as performance context instead of blindly copying leaderboard rank into live trades.
- Let users evaluate explicit public copy signals (leader, ticker, side, price) and only place orders after passing strict leaderboard, price, liquidity, category, rank, ROI, and history gates while preserving the existing dry-run/live safety gates.

### Description
- Added social ingestion helpers in `src/kalshi_bot/social.py` to normalize leaderboard rows from a local JSON export or an optional Apify scraper and to rank/filter traders for watchlists.
- Added copy-trading guards in `src/kalshi_bot/copy_trading.py` that load explicit `signals.json` and evaluate each signal against leaderboard-qualified traders and market metadata before approving trades.
- Extended the CLI (`src/kalshi_bot/cli.py`) with `kalshi-bot leaderboard` and `kalshi-bot copy` commands, dry-run output, and wiring to fetch market metadata using a new `get_market` client helper.
- Exposed `get_market` in `src/kalshi_bot/client.py`, extended runtime settings in `src/kalshi_bot/config.py`, updated `.env.example` with Apify and copy-trading guardrail variables, and documented the workflow in `README.md`.
- Added unit tests for leaderboard normalization/filtering, copy-signal evaluation, the `get_market` endpoint, and config behavior under `tests/`.

### Testing
- Ran `python -m compileall src tests`, which succeeded.
- Ran the test suite with `python -m pytest`, all tests passed (`10 passed`).
- Exercised the CLI leaderboard flow with `PYTHONPATH=src python -m kalshi_bot.cli leaderboard --file "$tmpdir/leaderboard.json" --limit 1`, which produced the expected dry-run output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a288e7657a8832dac360de9d2c54941)